### PR TITLE
feat(application): validação de regra de negócio para garantir unicidade do ticker no registro de produto

### DIFF
--- a/src/FinTrack.Application/UseCases/Products/RegisterProduct/RegisterProductCommandHandler.cs
+++ b/src/FinTrack.Application/UseCases/Products/RegisterProduct/RegisterProductCommandHandler.cs
@@ -43,6 +43,13 @@ public sealed class RegisterProductCommandHandler : IRequestHandler<RegisterProd
 
         try
         {
+            var existingProduct = await _unitOfWork.Products.GetByTickerAsync(request.Ticker, cancellationToken);
+            if (existingProduct is not null)
+            {
+                _logger.LogWarning("Tentativa de registro com ticker duplicado: {Ticker}", request.Ticker);
+                throw new ApplicationException($"Já existe um produto registrado com o ticker '{request.Ticker}'.");
+            }
+
             var currency = new Currency(request.CurrencyCode);
 
             var product = new Product(


### PR DESCRIPTION
**Validação de unicidade de ticker ao registrar novo produto**

**_O que foi feito:_**

- Implementação de regra de negócio para impedir o cadastro de produtos com ticker já existente.
- Validação feita diretamente no RegisterProductCommandHandler com injeção do repositório.
- Lançamento de ApplicationException em caso de violação.