### PR TITLE
test(integration): ampliando cobertura de testes para o caso de uso RegisterProduct 

### DIFF
--- a/tests/FinTrack.IntegrationTests/Setup/CustomWebApplicationFactory.cs
+++ b/tests/FinTrack.IntegrationTests/Setup/CustomWebApplicationFactory.cs
@@ -54,6 +54,14 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>, IAsyn
     }
 
     /// <summary>
+    /// Encerra o container do banco de dados utilizado durante os testes de integração.
+    /// </summary>
+    public async Task StopSqlContainerAsync()
+    {
+        await _sqlContainer.StopAsync();
+    }
+
+    /// <summary>
     /// Encerra o container após os testes.
     /// </summary>
     async Task IAsyncLifetime.DisposeAsync()


### PR DESCRIPTION
### **Testes de Integração – RegisterProduct**

**_O que foi feito:_**

- Expansão dos testes de integração para o caso de uso **RegisterProduct**, cobrindo cenários negativos:
  - **Validações de regra de negócio**:
    - Tipo de produto inválido resulta em exceção com mensagem apropriada e status **400 (BadRequest)**.
    - Categoria inválida resulta em exceção com mensagem apropriada e status **400 (BadRequest)**.
    - Falha de persistência no banco de dados é tratada via _ExceptionMiddleware_, retornando status **500 (InternalServerError)**.
