### PR TITLE
feat(infrastructure): migração do banco de dados de SQL Server para P…

### DIFF
--- a/src/FinTrack.API/appsettings.json
+++ b/src/FinTrack.API/appsettings.json
@@ -34,7 +34,7 @@
     ]
   },
   "ConnectionStrings": {
-    "DefaultConnection": "Server=localhost,1433;Database=FinTrackDb;User Id=sa;Password=FinTrack@123;TrustServerCertificate=True;"
+    "DefaultConnection": "Host=localhost;Port=5432;Database=FinTrackDb;Username=postgres;Password=FinTrack123"
   },
   "AlphaVantage": {
     "ApiKey": "pwd",

--- a/src/FinTrack.Configuration/DependencyInjection/IocConfiguration.cs
+++ b/src/FinTrack.Configuration/DependencyInjection/IocConfiguration.cs
@@ -90,7 +90,7 @@ public static class IocConfiguration
 
         services.AddDbContext<FinTrackDbContext>(options =>
         {
-            options.UseSqlServer(connectionString);
+            options.UseNpgsql(connectionString);
         });
 
         // Registro de repositórios
@@ -136,7 +136,7 @@ public static class IocConfiguration
         var connectionString = configuration.GetConnectionString("DefaultConnection");
 
         services.AddHealthChecks()
-            .AddSqlServer(connectionString!, name: "sqlserver", tags: new[] { "db", "sql", "infra" });
+            .AddNpgSql(connectionString!, name: "postgresql", tags: new[] { "db", "sql", "infra" });
 
         return services;
     }

--- a/src/FinTrack.Configuration/FinTrack.Configuration.csproj
+++ b/src/FinTrack.Configuration/FinTrack.Configuration.csproj
@@ -12,10 +12,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="9.0.0" />
 		<PackageReference Include="FluentValidation.AspNetCore" Version="11.3.0" />
 		<PackageReference Include="MediatR" Version="12.4.1" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.3" />
+		<PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="9.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.3" />
 		<PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
 		<PackageReference Include="Serilog.Settings.Configuration" Version="9.0.0" />

--- a/src/FinTrack.Configuration/Middlewares/ExceptionMiddleware.cs
+++ b/src/FinTrack.Configuration/Middlewares/ExceptionMiddleware.cs
@@ -1,9 +1,9 @@
 ﻿using FinTrack.Domain.Exceptions;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Npgsql;
 using System.Net;
 using System.Text.Json;
 
@@ -64,7 +64,7 @@ public class ExceptionMiddleware
             DomainException domainEx => (HttpStatusCode.BadRequest, domainEx.Message),
             ApplicationException appEx => (HttpStatusCode.BadRequest, appEx.Message),
             KeyNotFoundException notFoundEx => (HttpStatusCode.NotFound, notFoundEx.Message),
-            SqlException sqlEx => (HttpStatusCode.InternalServerError, "Erro ao acessar o banco de dados."),
+            PostgresException sqlEx => (HttpStatusCode.InternalServerError, "Erro ao acessar o banco de dados."),
             _ => (HttpStatusCode.InternalServerError, "Erro interno inesperado. Tente novamente mais tarde.")
         };
 

--- a/src/FinTrack.Infrastructure/FinTrack.Infrastructure.csproj
+++ b/src/FinTrack.Infrastructure/FinTrack.Infrastructure.csproj
@@ -1,21 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <ItemGroup>
-    <ProjectReference Include="..\FinTrack.Application\FinTrack.Application.csproj" />
-    <ProjectReference Include="..\FinTrack.Domain\FinTrack.Domain.csproj" />
-    <ProjectReference Include="..\FinTrack.Messages\FinTrack.Messages.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\FinTrack.Application\FinTrack.Application.csproj" />
+		<ProjectReference Include="..\FinTrack.Domain\FinTrack.Domain.csproj" />
+		<ProjectReference Include="..\FinTrack.Messages\FinTrack.Messages.csproj" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.3">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.3" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.3" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.3">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.3" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.3" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.3" />
+	</ItemGroup>
 
 	<PropertyGroup>
 		<TargetFramework>net9.0</TargetFramework>

--- a/src/FinTrack.Infrastructure/Persistence/Migrations/20250425043359_InitialPostgresMigration.Designer.cs
+++ b/src/FinTrack.Infrastructure/Persistence/Migrations/20250425043359_InitialPostgresMigration.Designer.cs
@@ -3,17 +3,17 @@ using System;
 using FinTrack.Infrastructure.Persistence.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
 namespace FinTrack.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(FinTrackDbContext))]
-    [Migration("20250326165956_InitialCreate")]
-    partial class InitialCreate
+    [Migration("20250425043359_InitialPostgresMigration")]
+    partial class InitialPostgresMigration
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -21,30 +21,30 @@ namespace FinTrack.Infrastructure.Persistence.Migrations
 #pragma warning disable 612, 618
             modelBuilder
                 .HasAnnotation("ProductVersion", "9.0.3")
-                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+                .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
-            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
             modelBuilder.Entity("FinTrack.Domain.Entities.PriceHistory", b =>
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTime>("Date")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<decimal>("Price")
                         .HasPrecision(18, 2)
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("numeric(18,2)");
 
                     b.Property<Guid>("ProductId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Source")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("character varying(100)");
 
                     b.HasKey("Id");
 
@@ -57,13 +57,13 @@ namespace FinTrack.Infrastructure.Persistence.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<int>("Category")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<decimal>("CurrentPrice")
                         .HasColumnType("decimal(18,2)");
@@ -71,15 +71,15 @@ namespace FinTrack.Infrastructure.Persistence.Migrations
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("character varying(100)");
 
                     b.Property<string>("Ticker")
                         .IsRequired()
                         .HasMaxLength(20)
-                        .HasColumnType("nvarchar(20)");
+                        .HasColumnType("character varying(20)");
 
                     b.Property<int>("Type")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.HasKey("Id");
 
@@ -100,12 +100,12 @@ namespace FinTrack.Infrastructure.Persistence.Migrations
                     b.OwnsOne("FinTrack.Domain.ValueObjects.Currency", "Currency", b1 =>
                         {
                             b1.Property<Guid>("ProductId")
-                                .HasColumnType("uniqueidentifier");
+                                .HasColumnType("uuid");
 
                             b1.Property<string>("Code")
                                 .IsRequired()
                                 .HasMaxLength(3)
-                                .HasColumnType("nvarchar(3)")
+                                .HasColumnType("character varying(3)")
                                 .HasColumnName("CurrencyCode");
 
                             b1.HasKey("ProductId");

--- a/src/FinTrack.Infrastructure/Persistence/Migrations/20250425043359_InitialPostgresMigration.cs
+++ b/src/FinTrack.Infrastructure/Persistence/Migrations/20250425043359_InitialPostgresMigration.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace FinTrack.Infrastructure.Persistence.Migrations
 {
     /// <inheritdoc />
-    public partial class InitialCreate : Migration
+    public partial class InitialPostgresMigration : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
@@ -15,14 +15,14 @@ namespace FinTrack.Infrastructure.Persistence.Migrations
                 name: "Products",
                 columns: table => new
                 {
-                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
-                    Name = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
-                    Ticker = table.Column<string>(type: "nvarchar(20)", maxLength: 20, nullable: false),
-                    Type = table.Column<int>(type: "int", nullable: false),
-                    Category = table.Column<int>(type: "int", nullable: false),
-                    CurrencyCode = table.Column<string>(type: "nvarchar(3)", maxLength: 3, nullable: false),
-                    CurrentPrice = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
-                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false)
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    Ticker = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    Type = table.Column<int>(type: "integer", nullable: false),
+                    Category = table.Column<int>(type: "integer", nullable: false),
+                    CurrencyCode = table.Column<string>(type: "character varying(3)", maxLength: 3, nullable: false),
+                    CurrentPrice = table.Column<decimal>(type: "numeric(18,2)", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
                 },
                 constraints: table =>
                 {
@@ -33,11 +33,11 @@ namespace FinTrack.Infrastructure.Persistence.Migrations
                 name: "PriceHistories",
                 columns: table => new
                 {
-                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
-                    ProductId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
-                    Date = table.Column<DateTime>(type: "datetime2", nullable: false),
-                    Price = table.Column<decimal>(type: "decimal(18,2)", precision: 18, scale: 2, nullable: false),
-                    Source = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false)
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    ProductId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Date = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Price = table.Column<decimal>(type: "numeric(18,2)", precision: 18, scale: 2, nullable: false),
+                    Source = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false)
                 },
                 constraints: table =>
                 {

--- a/src/FinTrack.Infrastructure/Persistence/Migrations/FinTrackDbContextModelSnapshot.cs
+++ b/src/FinTrack.Infrastructure/Persistence/Migrations/FinTrackDbContextModelSnapshot.cs
@@ -3,8 +3,8 @@ using System;
 using FinTrack.Infrastructure.Persistence.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
@@ -18,30 +18,30 @@ namespace FinTrack.Infrastructure.Persistence.Migrations
 #pragma warning disable 612, 618
             modelBuilder
                 .HasAnnotation("ProductVersion", "9.0.3")
-                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+                .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
-            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
             modelBuilder.Entity("FinTrack.Domain.Entities.PriceHistory", b =>
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<DateTime>("Date")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<decimal>("Price")
                         .HasPrecision(18, 2)
-                        .HasColumnType("decimal(18,2)");
+                        .HasColumnType("numeric(18,2)");
 
                     b.Property<Guid>("ProductId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<string>("Source")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("character varying(100)");
 
                     b.HasKey("Id");
 
@@ -54,13 +54,13 @@ namespace FinTrack.Infrastructure.Persistence.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("uuid");
 
                     b.Property<int>("Category")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<decimal>("CurrentPrice")
                         .HasColumnType("decimal(18,2)");
@@ -68,15 +68,15 @@ namespace FinTrack.Infrastructure.Persistence.Migrations
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("character varying(100)");
 
                     b.Property<string>("Ticker")
                         .IsRequired()
                         .HasMaxLength(20)
-                        .HasColumnType("nvarchar(20)");
+                        .HasColumnType("character varying(20)");
 
                     b.Property<int>("Type")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.HasKey("Id");
 
@@ -97,12 +97,12 @@ namespace FinTrack.Infrastructure.Persistence.Migrations
                     b.OwnsOne("FinTrack.Domain.ValueObjects.Currency", "Currency", b1 =>
                         {
                             b1.Property<Guid>("ProductId")
-                                .HasColumnType("uniqueidentifier");
+                                .HasColumnType("uuid");
 
                             b1.Property<string>("Code")
                                 .IsRequired()
                                 .HasMaxLength(3)
-                                .HasColumnType("nvarchar(3)")
+                                .HasColumnType("character varying(3)")
                                 .HasColumnName("CurrencyCode");
 
                             b1.HasKey("ProductId");

--- a/tests/FinTrack.IntegrationTests/FinTrack.IntegrationTests.csproj
+++ b/tests/FinTrack.IntegrationTests/FinTrack.IntegrationTests.csproj
@@ -19,9 +19,9 @@
 		<PackageReference Include="Dapper" Version="2.1.66" />
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.3" />
 		<PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.1" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.3" />
+		<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.3" />
+		<PackageReference Include="Testcontainers.PostgreSql" Version="4.4.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-		<PackageReference Include="Testcontainers.MsSql" Version="3.8.0" />
 		<PackageReference Include="xunit" Version="2.9.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
 		<PackageReference Include="FluentAssertions" Version="8.2.0" />

--- a/tests/FinTrack.IntegrationTests/Infrastructure/MigrationExecutionTests.cs
+++ b/tests/FinTrack.IntegrationTests/Infrastructure/MigrationExecutionTests.cs
@@ -1,7 +1,7 @@
 ﻿using Dapper;
 using FluentAssertions;
-using Microsoft.Data.SqlClient;
 using FinTrack.IntegrationTests.Setup;
+using Npgsql;
 
 namespace FinTrack.IntegrationTests.Infrastructure;
 
@@ -13,12 +13,12 @@ public class MigrationExecutionTests : IntegrationTestBase
     public async Task Should_Apply_Migrations_And_Create_Tables()
     {
         // Arrange
-        using var connection = new SqlConnection(_factory.ConnectionString);
+        using var connection = new NpgsqlConnection(_factory.ConnectionString);
         await connection.OpenAsync();
 
         // Act
         var appliedMigrations = await connection.QueryAsync<string>(
-            "SELECT [MigrationId] FROM [__EFMigrationsHistory];");
+            @"SELECT ""MigrationId"" FROM ""__EFMigrationsHistory"";");
 
         // Assert
         appliedMigrations.Should().NotBeEmpty("Porque a aplicação deve aplicar pelo menos uma migration válida ao inicializar o banco");

--- a/tests/FinTrack.IntegrationTests/Setup/CustomWebApplicationFactory.cs
+++ b/tests/FinTrack.IntegrationTests/Setup/CustomWebApplicationFactory.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Testcontainers.MsSql;
+using Testcontainers.PostgreSql;
 
 namespace FinTrack.IntegrationTests.Setup;
 
@@ -12,7 +12,7 @@ namespace FinTrack.IntegrationTests.Setup;
 /// </summary>
 public class CustomWebApplicationFactory : WebApplicationFactory<Program>, IAsyncLifetime
 {
-    private readonly MsSqlContainer _sqlContainer = new MsSqlBuilder().Build();
+    private readonly PostgreSqlContainer _sqlContainer = new PostgreSqlBuilder().Build();
 
     /// <summary>
     /// Obtém a string de conexão atual do banco de dados criado dinamicamente.
@@ -38,7 +38,7 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>, IAsyn
             // Injeta um novo contexto com a connection string do container
             services.AddDbContext<FinTrackDbContext>(options =>
             {
-                options.UseSqlServer(_sqlContainer.GetConnectionString());
+                options.UseNpgsql(_sqlContainer.GetConnectionString());
             });
         });
 


### PR DESCRIPTION
### **Migração do Banco de Dados para PostgreSQL**

**_O que foi feito:_**

- Substituição completa do SQL Server por PostgreSQL como banco principal da aplicação.
- Ajustes no **DbContext** e connection string para uso do provedor **Npgsql**.
- Atualização do **Testcontainers** para criação de containers PostgreSQL nos testes de integração.
- Alteração de queries específicas nos testes, como _**Dapper**_ e _**EF Migrations**_ para sintaxe compatível com PostgreSQL.
- Adaptação do HealthCheck (**AddNpgSql**) e configuração de connection string.
- Ajuste no teste **Should_Apply_Migrations_And_Create_Tables** para verificar corretamente as migrações no PostgreSQL.

**_Observações:_**

- Essa alteração foi essencial para preparar o ambiente da aplicação para a implantação na AWS, aproveitando o _**free tier**_ do Amazon RDS (_**PostgreSQL**_).
- Testes de integração e HealthCheck estão atualizados e validados com a nova estrutura.
